### PR TITLE
Remove mozmail.com

### DIFF
--- a/blacklist.txt
+++ b/blacklist.txt
@@ -66968,7 +66968,6 @@ mozillafirefox.ga
 mozillafirefox.gq
 mozillafirefox.ml
 mozillafirefox.tk
-mozmail.com
 mozmail.info
 mozzasiatopizzavalencia.com
 mp-j.cf


### PR DESCRIPTION
I'm a developer for [Firefox Relay](https://relay.firefox.com/). Back in 2021, we took over the mozmail.com domain for our aliases. We are operating Relay with a number of features that I think mitigate the risks that these aliases pose:

* Bounces & deliver-ability - if our user disables an @mozmail.com alias, we DO NOT trigger a bounce. Instead, [we silently drop the email](https://github.com/mozilla/fx-private-relay/blob/4ccc3957076b37d9b263241e0bd727f41893ac15/emails/views.py#L406-L422).
* Anti-abuse protections - we limit our free users to 5 total aliases, and we rate-limit our premium customers so they cannot create large-scale throw-away aliases for abusive sign-ups and behaviors.

So, we'd like to have mozmail.com removed from the disposable email domains list, please.